### PR TITLE
fix crash.

### DIFF
--- a/MLeaksFinder.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/MLeaksFinder.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/MLeaksFinder/UINavigationController+MemoryLeak.m
+++ b/MLeaksFinder/UINavigationController+MemoryLeak.m
@@ -41,6 +41,11 @@ static const void *const kPoppedDetailVCKey = &kPoppedDetailVCKey;
 - (UIViewController *)swizzled_popViewControllerAnimated:(BOOL)animated {
     UIViewController *poppedViewController = [self swizzled_popViewControllerAnimated:animated];
     
+    // Navigation VC's rootViewController is the last VC in Navigation VC's viewControllers
+    if (!poppedViewController) {
+        return nil;
+    }
+    
     // Detail VC in UISplitViewController is not dealloced until another detail VC is shown
     if (self.splitViewController &&
         self.splitViewController.viewControllers.firstObject == self &&


### PR DESCRIPTION
Navigation VC's rootViewController is the last VC in Navigation VC's viewControllers, pop will crash (poppedViewController = nil, objc_setAssociatedObject() crash)