### PR TITLE
Add _UIAlertControllerView and UIAlertController to whiteList

### DIFF
--- a/MLeaksFinder/NSObject+MemoryLeak.m
+++ b/MLeaksFinder/NSObject+MemoryLeak.m
@@ -74,6 +74,8 @@ const void *const kLatestSenderKey = &kLatestSenderKey;
                      @"UIFieldEditor", // UIAlertControllerTextField
                      @"UINavigationBar",
                      @"_UIAlertControllerActionView",
+                     @"_UIAlertControllerView",
+                     @"UIAlertController",
                      nil];
     });
     return whiteList;


### PR DESCRIPTION
一般的AlertView确实有报内存泄露， 还有`UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:@[self.url] applicationActivities:@[]]; [self presentViewController:activityViewController animated:YES completion:nil];` 也会报泄露