### PR TITLE
Refactor with aspects

### DIFF
--- a/MLeaksFinder.podspec
+++ b/MLeaksFinder.podspec
@@ -39,4 +39,6 @@ Pod::Spec.new do |s|
   s.public_header_files = 'MLeaksFinder/MLeaksFinder.h', 'MLeaksFinder/NSObject+MemoryLeak.h'
   # s.frameworks = 'UIKit', 'MapKit'
   s.dependency 'FBRetainCycleDetector'
+  s.dependency 'Aspects'
+  
 end

--- a/MLeaksFinder/NSObject+MemoryLeak.h
+++ b/MLeaksFinder/NSObject+MemoryLeak.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "Aspects.h"
 
 #define MLCheck(TARGET) [self willReleaseObject:(TARGET) relationship:@#TARGET];
 
@@ -20,6 +21,9 @@
 
 - (NSArray *)viewStack;
 
-+ (void)swizzleSEL:(SEL)originalSEL withSEL:(SEL)swizzledSEL;
++ (void)mlfAspect_hookSelector:(SEL)selector
+                   withOptions:(AspectOptions)options
+                    usingBlock:(id)block
+                         error:(NSError **)error;
 
 @end

--- a/MLeaksFinder/NSObject+MemoryLeak.m
+++ b/MLeaksFinder/NSObject+MemoryLeak.m
@@ -127,9 +127,12 @@ const void *const kLatestSenderKey = &kLatestSenderKey;
     return whiteList;
 }
 
-+ (void)swizzleSEL:(SEL)originalSEL withSEL:(SEL)swizzledSEL {
++ (void)mlfAspect_hookSelector:(SEL)selector
+                   withOptions:(AspectOptions)options
+                    usingBlock:(id)block
+                         error:(NSError *__autoreleasing *)error {
 #if _INTERNAL_MLF_ENABLED
-    
+
 #if _INTERNAL_MLF_RC_ENABLED
     // Just find a place to set up FBRetainCycleDetector.
     static dispatch_once_t onceToken;
@@ -139,26 +142,12 @@ const void *const kLatestSenderKey = &kLatestSenderKey;
         });
     });
 #endif
-    
-    Class class = [self class];
-    
-    Method originalMethod = class_getInstanceMethod(class, originalSEL);
-    Method swizzledMethod = class_getInstanceMethod(class, swizzledSEL);
-    
-    BOOL didAddMethod =
-    class_addMethod(class,
-                    originalSEL,
-                    method_getImplementation(swizzledMethod),
-                    method_getTypeEncoding(swizzledMethod));
-    
-    if (didAddMethod) {
-        class_replaceMethod(class,
-                            swizzledSEL,
-                            method_getImplementation(originalMethod),
-                            method_getTypeEncoding(originalMethod));
-    } else {
-        method_exchangeImplementations(originalMethod, swizzledMethod);
-    }
+
+    [NSObject aspect_hookSelector:selector
+                      withOptions:options
+                       usingBlock:block
+                            error:error];
+
 #endif
 }
 

--- a/MLeaksFinder/UINavigationController+MemoryLeak.m
+++ b/MLeaksFinder/UINavigationController+MemoryLeak.m
@@ -9,6 +9,7 @@
 #import "UINavigationController+MemoryLeak.h"
 #import "NSObject+MemoryLeak.h"
 #import <objc/runtime.h>
+#import "Aspects.h"
 
 #if _INTERNAL_MLF_ENABLED
 
@@ -17,67 +18,66 @@ static const void *const kPoppedDetailVCKey = &kPoppedDetailVCKey;
 @implementation UINavigationController (MemoryLeak)
 
 + (void)load {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        [self swizzleSEL:@selector(pushViewController:animated:) withSEL:@selector(swizzled_pushViewController:animated:)];
-        [self swizzleSEL:@selector(popViewControllerAnimated:) withSEL:@selector(swizzled_popViewControllerAnimated:)];
-        [self swizzleSEL:@selector(popToViewController:animated:) withSEL:@selector(swizzled_popToViewController:animated:)];
-        [self swizzleSEL:@selector(popToRootViewControllerAnimated:) withSEL:@selector(swizzled_popToRootViewControllerAnimated:)];
-    });
-}
+    [UINavigationController mlfAspect_hookSelector:@selector(pushViewController:animated:)
+                                    withOptions:AspectPositionBefore
+                                     usingBlock:^(id<AspectInfo> aspectInfo) {
+                                         UINavigationController *navigationController = (UINavigationController *)aspectInfo.instance;
+                                         if (navigationController.splitViewController) {
+                                             id detailViewController = objc_getAssociatedObject(self, kPoppedDetailVCKey);
+                                             if ([detailViewController isKindOfClass:[UIViewController class]]) {
+                                                 [detailViewController willDealloc];
+                                                 objc_setAssociatedObject(self, kPoppedDetailVCKey, nil, OBJC_ASSOCIATION_RETAIN);
+                                             }
+                                         }
+                                     }
+                                          error:nil];
 
-- (void)swizzled_pushViewController:(UIViewController *)viewController animated:(BOOL)animated {
-    if (self.splitViewController) {
-        id detailViewController = objc_getAssociatedObject(self, kPoppedDetailVCKey);
-        if ([detailViewController isKindOfClass:[UIViewController class]]) {
-            [detailViewController willDealloc];
-            objc_setAssociatedObject(self, kPoppedDetailVCKey, nil, OBJC_ASSOCIATION_RETAIN);
-        }
-    }
-    
-    [self swizzled_pushViewController:viewController animated:animated];
-}
+    [UINavigationController mlfAspect_hookSelector:@selector(popViewControllerAnimated:)
+                                    withOptions:AspectPositionInstead
+                                     usingBlock:^(id<AspectInfo> aspectInfo, BOOL animated){
+                                         [aspectInfo.originalInvocation setArgument:&animated atIndex:2];
+                                         [aspectInfo.originalInvocation invoke];
+                                         UIViewController *poppedViewController;
+                                         [aspectInfo.originalInvocation getReturnValue:&poppedViewController];
 
-- (UIViewController *)swizzled_popViewControllerAnimated:(BOOL)animated {
-    UIViewController *poppedViewController = [self swizzled_popViewControllerAnimated:animated];
-    
-    if (!poppedViewController) {
-        return nil;
-    }
-    
-    // Detail VC in UISplitViewController is not dealloced until another detail VC is shown
-    if (self.splitViewController &&
-        self.splitViewController.viewControllers.firstObject == self &&
-        self.splitViewController == poppedViewController.splitViewController) {
-        objc_setAssociatedObject(self, kPoppedDetailVCKey, poppedViewController, OBJC_ASSOCIATION_RETAIN);
-        return poppedViewController;
-    }
-    
-    // VC is not dealloced until disappear when popped using a left-edge swipe gesture
-    extern const void *const kHasBeenPoppedKey;
-    objc_setAssociatedObject(poppedViewController, kHasBeenPoppedKey, @(YES), OBJC_ASSOCIATION_RETAIN);
-    
-    return poppedViewController;
-}
+                                         if (poppedViewController) {
+                                             UINavigationController *navigationController = (UINavigationController *)aspectInfo.instance;
+                                             // Detail VC in UISplitViewController is not dealloced until another detail VC is shown
+                                             if (navigationController.splitViewController &&
+                                                 navigationController.splitViewController.viewControllers.firstObject == navigationController &&
+                                                 navigationController.splitViewController == poppedViewController.splitViewController) {
+                                                 objc_setAssociatedObject(navigationController, kPoppedDetailVCKey, poppedViewController, OBJC_ASSOCIATION_RETAIN);
+                                             }
+                                             else {
+                                                 // VC is not deallocated until disappear when popped using a left-edge swipe gesture
+                                                 extern const void *const kHasBeenPoppedKey;
+                                                 objc_setAssociatedObject(poppedViewController, kHasBeenPoppedKey, @(YES), OBJC_ASSOCIATION_RETAIN);
+                                             }
+                                         }
+                                     }
+                                          error:nil];
 
-- (NSArray<UIViewController *> *)swizzled_popToViewController:(UIViewController *)viewController animated:(BOOL)animated {
-    NSArray<UIViewController *> *poppedViewControllers = [self swizzled_popToViewController:viewController animated:animated];
-    
-    for (UIViewController *viewController in poppedViewControllers) {
-        [viewController willDealloc];
-    }
-    
-    return poppedViewControllers;
-}
+    [UINavigationController mlfAspect_hookSelector:@selector(popToViewController:animated:)
+                                    withOptions:AspectPositionAfter
+                                     usingBlock:^(id<AspectInfo> aspectInfo) {
+                                         NSArray<UIViewController *> *poppedViewControllers;
+                                         [aspectInfo.originalInvocation getReturnValue:&poppedViewControllers];
+                                         for (UIViewController *viewController in poppedViewControllers) {
+                                             [viewController willDealloc];
+                                         }
+                                     }
+                                          error:nil];
 
-- (NSArray<UIViewController *> *)swizzled_popToRootViewControllerAnimated:(BOOL)animated {
-    NSArray<UIViewController *> *poppedViewControllers = [self swizzled_popToRootViewControllerAnimated:animated];
-    
-    for (UIViewController *viewController in poppedViewControllers) {
-        [viewController willDealloc];
-    }
-    
-    return poppedViewControllers;
+    [UINavigationController mlfAspect_hookSelector:@selector(popToRootViewControllerAnimated:)
+                                    withOptions:AspectPositionAfter
+                                     usingBlock:^(id<AspectInfo> aspectInfo) {
+                                         NSArray<UIViewController *> *poppedViewControllers;
+                                         [aspectInfo.originalInvocation getReturnValue:&poppedViewControllers];
+                                         for (UIViewController *viewController in poppedViewControllers) {
+                                             [viewController willDealloc];
+                                         }
+                                     }
+                                          error:nil];
 }
 
 - (BOOL)willDealloc {

--- a/MLeaksFinder/UITouch+MemoryLeak.m
+++ b/MLeaksFinder/UITouch+MemoryLeak.m
@@ -8,6 +8,7 @@
 
 #import "UITouch+MemoryLeak.h"
 #import <objc/runtime.h>
+#import "Aspects.h"
 
 #if _INTERNAL_MLF_ENABLED
 
@@ -16,21 +17,17 @@ extern const void *const kLatestSenderKey;
 @implementation UITouch (MemoryLeak)
 
 + (void)load {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        [self swizzleSEL:@selector(setView:) withSEL:@selector(swizzled_setView:)];
-    });
-}
-
-- (void)swizzled_setView:(UIView *)view {
-    [self swizzled_setView:view];
-    
-    if (view) {
-        objc_setAssociatedObject([UIApplication sharedApplication],
-                                 kLatestSenderKey,
-                                 @((uintptr_t)view),
-                                 OBJC_ASSOCIATION_RETAIN);
-    }
+    [UITouch mlfAspect_hookSelector:@selector(setView:)
+                     withOptions:AspectPositionAfter
+                      usingBlock:^(id<AspectInfo> info, UIView *view) {
+                          if (view) {
+                              objc_setAssociatedObject([UIApplication sharedApplication],
+                                                       kLatestSenderKey,
+                                                       @((uintptr_t)view),
+                                                       OBJC_ASSOCIATION_RETAIN);
+                          }
+                      }
+                           error:nil];
 }
 
 @end

--- a/Podfile
+++ b/Podfile
@@ -7,5 +7,6 @@ target 'MLeaksFinder' do
 
   # Pods for MLeaksFinder
   pod 'FBRetainCycleDetector'
+  pod 'Aspects'
 
 end


### PR DESCRIPTION
I would love to integrate MLeaksFinder to help tune my app performance but it turns out there's a conflict between MLeaksFinder and my own pod [UIGuard](https://github.com/huayu0723/UIGuard.git), which has hooked the same selectors as the former. My solution is to refactor the MLeaksFinder pod with [Aspects](https://github.com/steipete/Aspects.git), just as what I did with [UIGuard](https://github.com/huayu0723/UIGuard.git). Considering the popularity of method swizzling, it might be a good practice for every hook to stay in peace.
Besides, 'dispatch_once' has been removed from +load method since it's thread-safe guaranteed by Apple.